### PR TITLE
Add an option to set the message identifier

### DIFF
--- a/sentry_groveio/models.py
+++ b/sentry_groveio/models.py
@@ -7,8 +7,8 @@ sentry_groveio.models
 """
 
 from django import forms
-from django.conf import settings
 
+from sentry.conf import settings
 from sentry.plugins import Plugin, register
 
 import urllib

--- a/sentry_groveio/models.py
+++ b/sentry_groveio/models.py
@@ -19,9 +19,15 @@ from django.utils import simplejson as json
 logger = logging.getLogger('sentry.plugins.groveio')
 
 
+form_options = (
+    ('project.name', 'Project Name'),
+    ('server_name', 'Server Name')
+)
+
 class GroveIoOptionsForm(forms.Form):
     token = forms.CharField(help_text="Your Grove.io channel token.")
     service_name = forms.CharField(help_text="Name of the service (displayed in the message)", initial='Sentry')
+    message_identifier = forms.ChoiceField(choices=form_options, help_text='')
     url = forms.CharField(help_text="(Optional) Service URL for the web client", required=False)
     icon_url = forms.CharField(help_text="(Optional) Icon for the service", required=False)
 
@@ -40,13 +46,30 @@ class GroveIoMessage(Plugin):
     def is_configured(self, project):
         return all((self.get_option(k, project) for k in ('token', 'service_name')))
 
+    def get_message_identifier(self, event):
+        """
+        Take the option selected in the management form and turn it into an
+        object attribute to get the string we need.
+        """
+        method = self.get_option('message_identifier', event.project)
+        if not method:
+            # in case this option hasn't been set before
+            return getattr(event, 'server_name')
+        instance = event
+        for attr in method.split('.'):
+            instance = getattr(instance, attr)
+        return instance
+
     def post_process(self, group, event, is_new, is_sample, **kwargs):
         if not is_new:
             return
         token = self.get_option('token', event.project)
         service = self.get_option('service_name', event.project)
         if token and service:
-            message = '[%s] %s: %s' % (event.server_name, event.get_level_display().upper(), event.error().encode('utf-8').split('\n')[0])
+            message = '[%s] %s: %s' % (
+                self.get_message_identifier(event),
+                event.get_level_display().upper(),
+                event.error().encode('utf-8').split('\n')[0])
             self.send_payload(token, service, event, group, message)
 
     def send_payload(self, token, service, event, group, message):


### PR DESCRIPTION
For when a server's hostname is meaningless (e.g. Heroku vms) and the project name would be more helpful.

(I can't work out why it thinks the commit with the import changes should be in there, maybe something to do with the rebasing. As far as I can tell they're identical apart from the hash)
